### PR TITLE
Always print the full report if more than the max violations are found.

### DIFF
--- a/src/main/java/se/bjurr/violations/gradle/plugin/ViolationsTask.java
+++ b/src/main/java/se/bjurr/violations/gradle/plugin/ViolationsTask.java
@@ -66,14 +66,16 @@ public class ViolationsTask extends DefaultTask {
             .withViolations(allParsedViolations) //
             .getReport(detailLevel);
 
-    getLogger().info("\n" + report);
-
     if (allParsedViolations.size() > maxViolations) {
       throw new ScriptException(
           "To many violations found, max is "
               + maxViolations
               + " but found "
-              + allParsedViolations.size());
+              + allParsedViolations.size()
+              + "\n"
+              + report);
+    } else {
+      getLogger().info("\n" + report);
     }
   }
 }


### PR DESCRIPTION
Fixes #1.