### PR TITLE
docs: report filename follow gitlab docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ task violations(type: se.bjurr.violations.gradle.plugin.ViolationsTask) {
  maxSeverityColumnWidth = 0
  maxLineColumnWidth = 0
  maxMessageColumnWidth = 50
- codeClimateFile = file('code-climate-file.json') // Will create a CodeClimate JSON report.
+ codeClimateFile = file('gl-code-quality-report.json') // Will create a CodeClimate JSON report.
  violationsFile = file('violations-file.json') // Will create a normalized JSON report.
 
 


### PR DESCRIPTION
GitLab report default filename: `gl-code-quality-report.json`

suggestion: follow it

https://docs.gitlab.com/ee/ci/testing/code_quality.html

<img width="696" alt="image" src="https://user-images.githubusercontent.com/4971414/196083547-9800eb43-636c-44f0-8986-6fcd1fa8bbaf.png">
